### PR TITLE
Httpf package with http abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Framework for Go services in go with zero dependency rule, so you can use it in 
     - [config](#config)
     - [di](#di)
     - [exception](#exception)
+    - [httpf](#httpf)
     - [logging](#logging)
     - [middleware](#middleware)
     - [policy](#policy)
@@ -55,6 +56,12 @@ See [example file](di/example_test.go) for runnable examples.
 It provides helper functions to facilitate work with errors. It allows to handle panic with ensured error (when panic is commonly mixed strings or errors), aggregate the errors and more.
 
 See [example file](exception/example_test.go) for runnable examples.
+
+### httpf
+
+httpf package provides abstraction over standard net/http to introduce dependency inversion rule. Mosly routing and server are abstracted which should help with mocking and facilitate using it without mistakes while providing harder to misuse API.
+
+See [example file](httpf/example_test.go) for runnable examples.
 
 ### logging
 

--- a/httpf/client.go
+++ b/httpf/client.go
@@ -142,7 +142,7 @@ func (c *client) Put(ctx context.Context, url string, body io.Reader) (*http.Res
 
 // Delete sends DELETE request
 func (c *client) Delete(ctx context.Context, url string) (*http.Response, error) {
-	req, err := http.NewRequest(http.MethodPost, url, nil)
+	req, err := http.NewRequest(http.MethodDelete, url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/httpf/client.go
+++ b/httpf/client.go
@@ -1,0 +1,155 @@
+package httpf
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// A Client is an HTTP client containing convenient API to send request with common
+// HTTP methods. Send function is the fundamental implementation for the Client which
+// provides a way to send request over HTTP and receive response
+type Client interface {
+	Send(ctx context.Context, req *http.Request) (*http.Response, error)
+
+	Get(ctx context.Context, url string) (*http.Response, error)
+	Post(ctx context.Context, url string, body io.Reader) (*http.Response, error)
+	PostForm(ctx context.Context, url string, form url.Values) (*http.Response, error)
+	Put(ctx context.Context, url string, body io.Reader) (*http.Response, error)
+	Delete(ctx context.Context, url string) (*http.Response, error)
+
+	Close()
+}
+
+// ClientOptions defines http.Client constructor parameters which can be set on NewClient
+type ClientOptions struct {
+	Transport     http.RoundTripper
+	CheckRedirect func(req *http.Request, via []*http.Request) error
+	Jar           http.CookieJar
+	Timeout       time.Duration
+}
+
+// ClientOption defines single function to mutate options
+type ClientOption func(*ClientOptions)
+
+// NewClientOptions returns a new instance of ClientOptions with is result of merged ClientOption slice
+func NewClientOptions(opts ...ClientOption) ClientOptions {
+	o := &ClientOptions{}
+	for _, opt := range opts {
+		opt(o)
+	}
+	return *o
+}
+
+// WithTransport sets option which specifies the mechanism by which individual HTTP requests are made
+func WithTransport(transport http.RoundTripper) ClientOption {
+	return func(o *ClientOptions) {
+		o.Transport = transport
+	}
+}
+
+// WithRedirectHandler sets option which specifies the policy for handling redirects
+func WithRedirectHandler(handler func(req *http.Request, via []*http.Request) error) ClientOption {
+	return func(o *ClientOptions) {
+		o.CheckRedirect = handler
+	}
+}
+
+// WithCookies sets option which specifies cookie jar used to insert relevant cookies
+// into every outbound Request and is updated with the cookie values of every inbound Response
+func WithCookies(cookieJar http.CookieJar) ClientOption {
+	return func(o *ClientOptions) {
+		o.Jar = cookieJar
+	}
+}
+
+// WithTimeout sets option which specifies a time limit for requests made by Client
+func WithTimeout(timeout time.Duration) ClientOption {
+	return func(o *ClientOptions) {
+		o.Timeout = timeout
+	}
+}
+
+// A client is Client adapter for http.Client
+type client struct {
+	c *http.Client
+}
+
+// NewClient returns a new instace of Client which is adapter for http.Client. Provided
+// options can be set optionally to pass the values in http.Client construction
+func NewClient(opts ...ClientOption) *client {
+	o := NewClientOptions(opts...)
+
+	return &client{
+		c: &http.Client{
+			Transport:     o.Transport,
+			CheckRedirect: o.CheckRedirect,
+			Jar:           o.Jar,
+			Timeout:       o.Timeout,
+		},
+	}
+}
+
+// Send calls http.Client Do function using request with given context
+func (c *client) Send(ctx context.Context, req *http.Request) (*http.Response, error) {
+	return c.c.Do(req.WithContext(ctx))
+}
+
+// Get sends GET request
+func (c *client) Get(ctx context.Context, url string) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return c.Send(ctx, req)
+}
+
+// Post sends POST request using application/json Content-Type as default value. To use different type
+// use Send with request containing appropiate Content-Type header
+func (c *client) Post(ctx context.Context, url string, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodPost, url, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set(ContentTypeHeader, ApplicationJsonType)
+	return c.Send(ctx, req)
+}
+
+// PostForm sends POST request using application/x-www-form-urlencoded Content-Type and encoded form values as body
+func (c *client) PostForm(ctx context.Context, url string, form url.Values) (*http.Response, error) {
+	body := io.NopCloser(strings.NewReader(form.Encode()))
+	req, err := http.NewRequest(http.MethodPost, url, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set(ContentTypeHeader, ApplicationFormEncodedType)
+	return c.Send(ctx, req)
+}
+
+// Put sends PUT request using application/json Content-Type as default value. To use different type
+// use Send with request containing appropiate Content-Type header
+func (c *client) Put(ctx context.Context, url string, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodPut, url, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set(ContentTypeHeader, ApplicationJsonType)
+	return c.Send(ctx, req)
+}
+
+// Delete sends DELETE request
+func (c *client) Delete(ctx context.Context, url string) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodPost, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return c.Send(ctx, req)
+}
+
+// Close calls http.Client CloseIdleConnections function
+func (c *client) Close() {
+	c.c.CloseIdleConnections()
+}

--- a/httpf/client_test.go
+++ b/httpf/client_test.go
@@ -50,7 +50,7 @@ func TestClientSend(t *testing.T) {
 			ctx:  context.TODO(),
 			req:  &http.Request{URL: googleUrl},
 			client: func(t *testing.T) Client {
-				return NewClient(WithTimeout(200 * time.Millisecond))
+				return NewClient(WithTimeout(time.Millisecond))
 			},
 			assertion: func(t *testing.T, result *http.Response, err error) {
 				assert.ErrorWith(t, err, context.DeadlineExceeded.Error())
@@ -62,14 +62,14 @@ func TestClientSend(t *testing.T) {
 			ctx:  context.TODO(),
 			req:  &http.Request{URL: googleUrl},
 			client: func(t *testing.T) Client {
-				counter1 := assert.Count(t, 2, "SetCookies was expected to be called")
-				counter2 := assert.Count(t, 2, "Cookies was expected to be called")
+				setCookiesCounter := assert.Count(t, 1, "SetCookies was expected to be called").AtLeast()
+				cookiesCounter := assert.Count(t, 1, "Cookies was expected to be called").AtLeast()
 				cookies := &mocks.CookiesJar{
 					OnSetCookies: func(u *url.URL, cookies []*http.Cookie) {
-						counter1.Inc()
+						setCookiesCounter.Inc()
 					},
 					OnCookies: func(u *url.URL) []*http.Cookie {
-						counter2.Inc()
+						cookiesCounter.Inc()
 						return nil
 					},
 				}

--- a/httpf/client_test.go
+++ b/httpf/client_test.go
@@ -1,0 +1,156 @@
+package httpf
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/Prastiwar/Go-flow/tests/assert"
+	"github.com/Prastiwar/Go-flow/tests/mocks"
+)
+
+func TestClientSend(t *testing.T) {
+	googleUrl, err := url.Parse("https://google.com/")
+	assert.NilError(t, err)
+
+	tests := []struct {
+		name      string
+		ctx       context.Context
+		req       *http.Request
+		client    func(t *testing.T) Client
+		assertion assert.ResultErrorFunc[*http.Response]
+	}{
+		{
+			name: "success-response",
+			ctx:  context.TODO(),
+			req:  &http.Request{URL: &url.URL{}},
+			client: func(t *testing.T) Client {
+				roundTripper := &mocks.RoundTripper{
+					OnRoundTrip: func(r *http.Request) (*http.Response, error) {
+						return &http.Response{
+							Status: "pass",
+						}, nil
+					},
+				}
+				return NewClient(WithTransport(roundTripper))
+			},
+			assertion: func(t *testing.T, result *http.Response, err error) {
+				assert.NilError(t, err)
+				assert.NotNil(t, result)
+				assert.Equal(t, "pass", result.Status)
+			},
+		},
+		{
+			name: "success-timeout",
+			ctx:  context.TODO(),
+			req:  &http.Request{URL: googleUrl},
+			client: func(t *testing.T) Client {
+				return NewClient(WithTimeout(200 * time.Millisecond))
+			},
+			assertion: func(t *testing.T, result *http.Response, err error) {
+				assert.ErrorWith(t, err, context.DeadlineExceeded.Error())
+				assert.Equal(t, nil, result)
+			},
+		},
+		{
+			name: "success-cookies",
+			ctx:  context.TODO(),
+			req:  &http.Request{URL: googleUrl},
+			client: func(t *testing.T) Client {
+				counter1 := assert.Count(t, 2, "SetCookies was expected to be called")
+				counter2 := assert.Count(t, 2, "Cookies was expected to be called")
+				cookies := &mocks.CookiesJar{
+					OnSetCookies: func(u *url.URL, cookies []*http.Cookie) {
+						counter1.Inc()
+					},
+					OnCookies: func(u *url.URL) []*http.Cookie {
+						counter2.Inc()
+						return nil
+					},
+				}
+				return NewClient(WithCookies(cookies))
+			},
+			assertion: func(t *testing.T, result *http.Response, err error) {
+			},
+		},
+		{
+			name: "success-redirect",
+			ctx:  context.TODO(),
+			req:  &http.Request{URL: googleUrl},
+			client: func(t *testing.T) Client {
+				return NewClient(WithRedirectHandler(func(req *http.Request, via []*http.Request) error {
+					return errors.New("test-redirect")
+				}))
+			},
+			assertion: func(t *testing.T, result *http.Response, err error) {
+				assert.ErrorWith(t, err, "test-redirect")
+				assert.NotNil(t, result)
+				assert.Equal(t, 301, result.StatusCode)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := tt.client(t)
+
+			got, err := c.Send(tt.ctx, tt.req)
+
+			c.Close()
+			tt.assertion(t, got, err)
+		})
+	}
+}
+
+func TestClientConenientMethods(t *testing.T) {
+	tests := []struct {
+		name      string
+		run       func(t *testing.T, c Client) (*http.Response, error)
+		assertion func(t *testing.T, req *http.Request)
+	}{
+		{
+			name: http.MethodGet,
+			run: func(t *testing.T, c Client) (*http.Response, error) {
+				return c.Get(context.TODO(), "test")
+			},
+			assertion: func(t *testing.T, req *http.Request) {
+				assert.NotNil(t, req)
+			},
+		},
+		// TODO: implement
+		// {
+		// 	name: http.MethodPost,
+		// 	// Post(ctx context.Context, url string, body io.Reader) (*http.Response, error)
+		// },
+		// {
+		// 	name: http.MethodPost,
+		// 	// PostForm(ctx context.Context, url string, form url.Values) (*http.Response, error)
+		// },
+		// {
+		// 	name: http.MethodPut,
+		// 	// Put(ctx context.Context, url string, body io.Reader) (*http.Response, error)
+		// },
+		// {
+		// 	name: http.MethodDelete,
+		// 	// Delete(ctx context.Context, url string) (*http.Response, error)
+		// },
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rt := &mocks.RoundTripper{
+				OnRoundTrip: func(r *http.Request) (*http.Response, error) {
+					tt.assertion(t, r)
+					assert.Equal(t, tt.name, r.Method, "method was invalid")
+					return &http.Response{}, nil
+				},
+			}
+			c := NewClient(WithTransport(rt))
+
+			_, _ = tt.run(t, c)
+		})
+	}
+}

--- a/httpf/consts.go
+++ b/httpf/consts.go
@@ -1,0 +1,29 @@
+package httpf
+
+const (
+	AcceptHeader                  = "Accept"
+	AcceptCharsetHeader           = "Accept-Charset"
+	AcceptEncodingHeader          = "Accept-Encoding"
+	AcceptLanguageHeader          = "Accept-Language"
+	AcceptRangesHeader            = "Accept-Ranges"
+	CacheControlHeader            = "Cache-Control"
+	CcHeader                      = "Cc"
+	ConnectionHeader              = "Connection"
+	ContentIdHeader               = "Content-Id"
+	ContentLanguageHeader         = "Content-Language"
+	ContentLengthHeader           = "Content-Length"
+	ContentTransferEncodingHeader = "Content-Transfer-Encoding"
+	ContentTypeHeader             = "Content-Type"
+	CookieHeader                  = "Cookie"
+	DateHeader                    = "Date"
+	ExpiresHeader                 = "Expires"
+	FromHeader                    = "From"
+	HostHeader                    = "Host"
+	LocationHeader                = "Location"
+	ServerHeader                  = "Server"
+	SetCookieHeader               = "Set-Cookie"
+	UserAgentHeader               = "User-Agent"
+
+	ApplicationJsonType        = "application/json"
+	ApplicationFormEncodedType = "application/x-www-form-urlencoded"
+)

--- a/httpf/example_test.go
+++ b/httpf/example_test.go
@@ -49,14 +49,14 @@ func Example() {
 		}
 	}))
 
-	mux.Post("/api/test/", httpf.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+	mux.Post("/api/test/", httpf.HandlerFunc(func(w httpf.ResponseWriter, r *http.Request) error {
 		result := struct {
 			Id string `json:"id"`
 		}{
 			Id: "1234",
 		}
 
-		return httpf.Json(w, http.StatusCreated, result)
+		return w.Response(http.StatusCreated, result)
 	}))
 
 	go func() {

--- a/httpf/example_test.go
+++ b/httpf/example_test.go
@@ -50,11 +50,6 @@ func Example() {
 	}))
 
 	mux.Post("/api/test/", httpf.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
-		err := errors.New("lel")
-		if err != nil {
-			return err
-		}
-
 		result := struct {
 			Id string `json:"id"`
 		}{
@@ -77,7 +72,7 @@ func Example() {
 
 	fmt.Println(resp.StatusCode)
 	body, _ := io.ReadAll(resp.Body)
-	fmt.Println(body)
+	fmt.Println(string(body))
 
 	// output:
 	// 201

--- a/httpf/example_test.go
+++ b/httpf/example_test.go
@@ -1,0 +1,85 @@
+package httpf_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+
+	"github.com/Prastiwar/Go-flow/httpf"
+)
+
+func Example() {
+	mux := httpf.NewServeMuxBuilder()
+
+	mux.WithErrorHandler(httpf.ErrorHandlerFunc(func(w http.ResponseWriter, r *http.Request, err error) {
+		// define standard structure for error response
+		type httpError struct {
+			Error string `json:"error"`
+			Code  int    `json:"code"`
+		}
+
+		// map infrastructure errors to http error response
+		var resultError httpError
+		if errors.Is(err, context.DeadlineExceeded) {
+			resultError = httpError{
+				Error: http.StatusText(http.StatusRequestTimeout),
+				Code:  http.StatusRequestTimeout,
+			}
+		} else {
+			resultError = httpError{
+				Error: http.StatusText(http.StatusInternalServerError),
+				Code:  http.StatusInternalServerError,
+			}
+		}
+
+		// marshal error and write to Response
+		result, err := json.Marshal(resultError)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		_, err = w.Write(result)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}))
+
+	mux.Post("/api/test/", httpf.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		err := errors.New("lel")
+		if err != nil {
+			return err
+		}
+
+		result := struct {
+			Id string `json:"id"`
+		}{
+			Id: "1234",
+		}
+
+		return httpf.Json(w, http.StatusCreated, result)
+	}))
+
+	go func() {
+		_ = httpf.NewServer("localhost:8080", mux.Build()).ListenAndServe()
+	}()
+
+	resp, err := http.Post("http://localhost:8080/api/test/", "application/json", bytes.NewBufferString("{}"))
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer resp.Body.Close()
+
+	fmt.Println(resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+	fmt.Println(body)
+
+	// output:
+	// 201
+	// {"id":"1234"}
+}

--- a/httpf/handler.go
+++ b/httpf/handler.go
@@ -2,31 +2,41 @@ package httpf
 
 import "net/http"
 
+// A ResponseWriter interface is used by an HTTP handler to
+// construct an HTTP response. It extends http.ResponseWriter with
+// Response function which should be used to share common response format
 type ResponseWriter interface {
 	http.ResponseWriter
 
 	Response(code int, data interface{}) error
 }
 
+// A jsonWriterDecorator implements ResponseWriter interface and provides
+// json writing for Response
 type jsonWriterDecorator struct {
 	http.ResponseWriter
 }
 
+// Response calls httpf.Json(d, code, data)
 func (d *jsonWriterDecorator) Response(code int, data interface{}) error {
 	return Json(d, code, data)
 }
 
-type Request interface {
-	// TODO: implement
-	PathParam(key string)
-}
-
+// A Handler responds to an HTTP request
+//
+// ServeHTTP should write reply headers and data to the ResponseWriter
+// and then return any occuring error. The error should be handler by
+// Router which should finish request process
 type Handler interface {
 	ServeHTTP(w ResponseWriter, r *http.Request) error
 }
 
+// The HandlerFunc type is an adapter to allow the use of ordinary
+// functions as HTTP handlers. If h is a function with
+// the appropriate signature, HandlerFunc(h) is a Handler that calls h
 type HandlerFunc func(w ResponseWriter, r *http.Request) error
 
+// ServeHTTP calls h(w, r)
 func (h HandlerFunc) ServeHTTP(w ResponseWriter, r *http.Request) error {
 	return h(w, r)
 }

--- a/httpf/handler.go
+++ b/httpf/handler.go
@@ -1,0 +1,13 @@
+package httpf
+
+import "net/http"
+
+type Handler interface {
+	ServeHTTP(w http.ResponseWriter, r *http.Request) error
+}
+
+type HandlerFunc func(w http.ResponseWriter, r *http.Request) error
+
+func (h HandlerFunc) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
+	return h(w, r)
+}

--- a/httpf/handler.go
+++ b/httpf/handler.go
@@ -2,12 +2,31 @@ package httpf
 
 import "net/http"
 
-type Handler interface {
-	ServeHTTP(w http.ResponseWriter, r *http.Request) error
+type ResponseWriter interface {
+	http.ResponseWriter
+
+	Response(code int, data interface{}) error
 }
 
-type HandlerFunc func(w http.ResponseWriter, r *http.Request) error
+type jsonWriterDecorator struct {
+	http.ResponseWriter
+}
 
-func (h HandlerFunc) ServeHTTP(w http.ResponseWriter, r *http.Request) error {
+func (d *jsonWriterDecorator) Response(code int, data interface{}) error {
+	return Json(d, code, data)
+}
+
+type Request interface {
+	// TODO: implement
+	PathParam(key string)
+}
+
+type Handler interface {
+	ServeHTTP(w ResponseWriter, r *http.Request) error
+}
+
+type HandlerFunc func(w ResponseWriter, r *http.Request) error
+
+func (h HandlerFunc) ServeHTTP(w ResponseWriter, r *http.Request) error {
 	return h(w, r)
 }

--- a/httpf/mux.go
+++ b/httpf/mux.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 )
 
+// serveMuxBuilder implements RouterBuilder interface with
+// building the http.ServeMux router.
 type serveMuxBuilder struct {
 	mu sync.RWMutex
 
@@ -13,46 +15,61 @@ type serveMuxBuilder struct {
 	writerDecorator func(http.ResponseWriter) ResponseWriter
 }
 
+// NewServeMuxBuilder returns RouterBuilder which build results in adapting
+// http.ServeMux implementation to handle errors and decorates http.ResponseWriter
 func NewServeMuxBuilder() *serveMuxBuilder {
 	return &serveMuxBuilder{
 		routes: make(map[string]map[string]Handler),
 	}
 }
 
+// Get registers handler to pattern using GET method
 func (b *serveMuxBuilder) Get(pattern string, handler Handler) RouteBuilder {
 	return b.handle(http.MethodGet, pattern, handler)
 }
 
+// Post registers handler to pattern using POST method
 func (b *serveMuxBuilder) Post(pattern string, handler Handler) RouteBuilder {
 	return b.handle(http.MethodPost, pattern, handler)
 }
 
+// Put registers handler to pattern using PUT method
 func (b *serveMuxBuilder) Put(pattern string, handler Handler) RouteBuilder {
 	return b.handle(http.MethodPut, pattern, handler)
 }
 
+// Delete registers handler to pattern using DELETE method
 func (b *serveMuxBuilder) Delete(pattern string, handler Handler) RouteBuilder {
 	return b.handle(http.MethodDelete, pattern, handler)
 }
 
+// Patch registers handler to pattern using PATCH method
 func (b *serveMuxBuilder) Patch(pattern string, handler Handler) RouteBuilder {
 	return b.handle(http.MethodPatch, pattern, handler)
 }
 
+// Options registers handler to pattern using OPTIONS method
 func (b *serveMuxBuilder) Options(pattern string, handler Handler) RouteBuilder {
 	return b.handle(http.MethodOptions, pattern, handler)
 }
 
+// WithErrorHandler sets ErrorHandler used in Build
 func (b *serveMuxBuilder) WithErrorHandler(handler ErrorHandler) RouteBuilder {
 	b.errorHandler = handler
 	return b
 }
 
+// WithWriterDecorator sets function which should decorate http.ResponseWriter coming from handler
 func (b *serveMuxBuilder) WithWriterDecorator(decorator func(http.ResponseWriter) ResponseWriter) RouteBuilder {
 	b.writerDecorator = decorator
 	return b
 }
 
+// Build registers the registered handlers in builder to http.ServeMux using mux.HandleFunc
+// which matches accurate HTTP method or returns MethodNotAllowed status. It also wraps handler with
+// proper error handling and decorating incoming http.ResponseWriter.
+// If ResponseWriter decorator was not set jsonWriterDecorator is used instead.
+// If ErrorHandler was not set just http.Error is called with Internal Server status.
 func (b *serveMuxBuilder) Build() Router {
 	mux := http.NewServeMux()
 	for route, handlers := range b.routes {
@@ -82,6 +99,7 @@ func (b *serveMuxBuilder) Build() Router {
 	return mux
 }
 
+// handle registers handler to given pattern with method
 func (b *serveMuxBuilder) handle(method string, pattern string, h Handler) RouteBuilder {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/httpf/mux.go
+++ b/httpf/mux.go
@@ -56,12 +56,13 @@ func (b *serveMuxBuilder) Build() Router {
 				http.Error(w, "", http.StatusMethodNotAllowed)
 				return
 			}
-			err := h.ServeHTTP(w, r)
 
-			if b.errorHandler != nil {
-				b.errorHandler.Handle(w, r, err)
-			} else {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
+			if err := h.ServeHTTP(w, r); err != nil {
+				if b.errorHandler != nil {
+					b.errorHandler.Handle(w, r, err)
+				} else {
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+				}
 			}
 		})
 	}

--- a/httpf/mux.go
+++ b/httpf/mux.go
@@ -1,0 +1,82 @@
+package httpf
+
+import (
+	"net/http"
+	"sync"
+)
+
+type serveMuxBuilder struct {
+	mu sync.RWMutex
+
+	routes       map[string]map[string]Handler
+	errorHandler ErrorHandler
+}
+
+func NewServeMuxBuilder() *serveMuxBuilder {
+	return &serveMuxBuilder{
+		routes: make(map[string]map[string]Handler),
+	}
+}
+
+func (b *serveMuxBuilder) Get(pattern string, handler Handler) RouteBuilder {
+	return b.handle(http.MethodGet, pattern, handler)
+}
+
+func (b *serveMuxBuilder) Post(pattern string, handler Handler) RouteBuilder {
+	return b.handle(http.MethodPost, pattern, handler)
+}
+
+func (b *serveMuxBuilder) Put(pattern string, handler Handler) RouteBuilder {
+	return b.handle(http.MethodPut, pattern, handler)
+}
+
+func (b *serveMuxBuilder) Delete(pattern string, handler Handler) RouteBuilder {
+	return b.handle(http.MethodDelete, pattern, handler)
+}
+
+func (b *serveMuxBuilder) Patch(pattern string, handler Handler) RouteBuilder {
+	return b.handle(http.MethodPatch, pattern, handler)
+}
+
+func (b *serveMuxBuilder) Options(pattern string, handler Handler) RouteBuilder {
+	return b.handle(http.MethodOptions, pattern, handler)
+}
+
+func (b *serveMuxBuilder) WithErrorHandler(handler ErrorHandler) RouteBuilder {
+	b.errorHandler = handler
+	return b
+}
+
+func (b *serveMuxBuilder) Build() Router {
+	mux := http.NewServeMux()
+	for route, handlers := range b.routes {
+		mux.HandleFunc(route, func(w http.ResponseWriter, r *http.Request) {
+			h, ok := handlers[r.Method]
+			if !ok {
+				http.Error(w, "", http.StatusMethodNotAllowed)
+				return
+			}
+			err := h.ServeHTTP(w, r)
+
+			if b.errorHandler != nil {
+				b.errorHandler.Handle(w, r, err)
+			} else {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+		})
+	}
+	return mux
+}
+
+func (b *serveMuxBuilder) handle(method string, pattern string, h Handler) RouteBuilder {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	p := b.routes[pattern]
+	if p == nil {
+		p = make(map[string]Handler)
+	}
+	p[method] = h
+	b.routes[pattern] = p
+	return b
+}

--- a/httpf/mux_test.go
+++ b/httpf/mux_test.go
@@ -1,0 +1,172 @@
+package httpf
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/Prastiwar/Go-flow/tests/assert"
+	"github.com/Prastiwar/Go-flow/tests/mocks"
+)
+
+func TestServeMux(t *testing.T) {
+	mux := NewServeMuxBuilder()
+
+	handlerFunc := func(name string) Handler {
+		counter := assert.Count(t, 1, name+" route was not called")
+		return HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+			counter.Inc()
+			return nil
+		})
+	}
+
+	router := mux.Get("/api/albums/", handlerFunc("Get")).
+		Post("/api/albums/", handlerFunc("Post")).
+		Put("/api/albums/", handlerFunc("Put")).
+		Delete("/api/albums/", handlerFunc("Delete")).
+		Options("/api/albums/", handlerFunc("Options")).
+		Patch("/api/albums/", handlerFunc("Patch")).
+		Build()
+
+	methods := []string{
+		http.MethodGet,
+		http.MethodPost,
+		http.MethodPut,
+		http.MethodDelete,
+		http.MethodOptions,
+		http.MethodPatch,
+	}
+
+	for _, method := range methods {
+		r, err := http.NewRequest(method, "http://localhost/api/albums/", nil)
+		assert.NilError(t, err)
+
+		router.ServeHTTP(&mocks.ResponseWriter{}, r)
+	}
+}
+
+func TestErrorHandler(t *testing.T) {
+	mux := NewServeMuxBuilder()
+	errHandler := errors.New("handler-error")
+
+	errorCounter := assert.Count(t, 1, "expected call to error handler")
+
+	router := mux.WithErrorHandler(ErrorHandlerFunc(func(w http.ResponseWriter, r *http.Request, err error) {
+		errorCounter.Inc()
+		assert.Equal(t, errHandler, err)
+	})).Get("/api/albums/", HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		return errHandler
+	})).Build()
+
+	r, err := http.NewRequest(http.MethodGet, "http://localhost/api/albums/", nil)
+	assert.NilError(t, err)
+
+	router.ServeHTTP(&mocks.ResponseWriter{}, r)
+}
+
+func TestServeMuxHandleGetError(t *testing.T) {
+	errHandle := errors.New("handler-error")
+
+	tests := []struct {
+		name          string
+		requestMethod string
+		errHandler    func(t *testing.T) ErrorHandler
+		writer        func(t *testing.T) http.ResponseWriter
+	}{
+		{
+			name:          "with-custom-handler",
+			requestMethod: http.MethodGet,
+			errHandler: func(t *testing.T) ErrorHandler {
+				errorCounter := assert.Count(t, 1, "expected call to error handler")
+				return ErrorHandlerFunc(func(w http.ResponseWriter, r *http.Request, err error) {
+					errorCounter.Inc()
+					assert.Equal(t, errHandle, err)
+				})
+			},
+			writer: func(t *testing.T) http.ResponseWriter {
+				m := &mocks.ResponseWriter{
+					OnHeader: func() http.Header {
+						t.Fatal("unexpected Header() function call")
+						return nil
+					},
+					OnWrite: func(b []byte) (int, error) {
+						t.Fatal("unexpected Header() function call")
+						return 0, nil
+					},
+					OnWriteHeader: func(code int) {
+						t.Fatal("unexpected Header() function call")
+					},
+				}
+				return m
+			},
+		},
+		{
+			name:          "with-default-handler",
+			requestMethod: http.MethodGet,
+			errHandler: func(t *testing.T) ErrorHandler {
+				return nil
+			},
+			writer: func(t *testing.T) http.ResponseWriter {
+				writeCounter := assert.Count(t, 1, "expected Write() call")
+				writeHeaderCounter := assert.Count(t, 1, "expected WriteHeader() call")
+				m := &mocks.ResponseWriter{
+					OnHeader: func() http.Header {
+						return http.Header{}
+					},
+					OnWrite: func(b []byte) (int, error) {
+						assert.Equal(t, errHandle.Error()+"\n", string(b))
+						writeCounter.Inc()
+						return 0, nil
+					},
+					OnWriteHeader: func(code int) {
+						assert.Equal(t, 500, code)
+						writeHeaderCounter.Inc()
+					},
+				}
+				return m
+			},
+		},
+		{
+			name:          "with-method-not-allowed",
+			requestMethod: http.MethodPost,
+			errHandler: func(t *testing.T) ErrorHandler {
+				return nil
+			},
+			writer: func(t *testing.T) http.ResponseWriter {
+				writeCounter := assert.Count(t, 1, "expected Write() call")
+				writeHeaderCounter := assert.Count(t, 1, "expected WriteHeader() call")
+				m := &mocks.ResponseWriter{
+					OnHeader: func() http.Header {
+						return http.Header{}
+					},
+					OnWrite: func(b []byte) (int, error) {
+						assert.Equal(t, "\n", string(b))
+						writeCounter.Inc()
+						return 0, nil
+					},
+					OnWriteHeader: func(code int) {
+						assert.Equal(t, http.StatusMethodNotAllowed, code)
+						writeHeaderCounter.Inc()
+					},
+				}
+				return m
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mux := NewServeMuxBuilder()
+
+			router := mux.WithErrorHandler(tt.errHandler(t)).
+				Get("/api/albums/", HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+					return errHandle
+				})).Build()
+
+			r, err := http.NewRequest(tt.requestMethod, "http://localhost/api/albums/", nil)
+			assert.NilError(t, err)
+
+			router.ServeHTTP(tt.writer(t), r)
+		})
+	}
+}

--- a/httpf/params.go
+++ b/httpf/params.go
@@ -1,0 +1,54 @@
+package httpf
+
+import (
+	"context"
+	"net/http"
+)
+
+type paramsKeyValue struct{}
+
+var paramsKey = &paramsKeyValue{}
+
+// ParamsParser is parser for request to retrieve path parameters.
+// Implementation should decide how to retrieve params based on values in specified http request.
+type ParamsParser interface {
+	ParseParams(r *http.Request) map[string]string
+}
+
+// The ParamsParserFunc type is an adapter to allow the use of ordinary
+// functions as ParamsParser. If p is a function with
+// the appropriate signature, ParamsParserFunc(p) is a ParamsParser that will return p
+type ParamsParserFunc func(r *http.Request) map[string]string
+
+// ParseParams returns p(r)
+func (p ParamsParserFunc) ParseParams(r *http.Request) map[string]string {
+	return p(r)
+}
+
+// HasParam returns true if key exists in path params map
+func HasParam(r *http.Request, key string) bool {
+	_, ok := Params(r)[key]
+	return ok
+}
+
+// Params returns raw value for path param by key. If no key was set it returns "".
+// To distinguish between empty value and value was not set use HasParam or Params directly
+func Param(r *http.Request, key string) string {
+	return Params(r)[key]
+}
+
+// Params retrieves path param values from request context or empty map if it was not set.
+// Router is responsible to decorate http request with WithParams using ParamsParser
+func Params(r *http.Request) map[string]string {
+	params := r.Context().Value(paramsKey)
+	if params == nil {
+		return make(map[string]string)
+	}
+	return params.(map[string]string)
+}
+
+// WithParams returns a shallow copy of r with its context changed to contain params as context value
+func WithParams(r *http.Request, params map[string]string) *http.Request {
+	ctx := context.WithValue(r.Context(), paramsKey, params)
+	return r.WithContext(ctx)
+}

--- a/httpf/params_test.go
+++ b/httpf/params_test.go
@@ -1,0 +1,22 @@
+package httpf
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/Prastiwar/Go-flow/tests/assert"
+)
+
+func TestParams(t *testing.T) {
+	req := &http.Request{}
+	has := HasParam(req, "one")
+	assert.Equal(t, false, has, "expected to have 'one' key")
+
+	r := WithParams(req, map[string]string{"one": "two"})
+
+	has = HasParam(r, "one")
+	assert.Equal(t, true, has, "expected to have 'one' key")
+
+	v := Param(r, "one")
+	assert.Equal(t, "two", v)
+}

--- a/httpf/responses.go
+++ b/httpf/responses.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 )
 
+// Json marshals the data and writes it to http.ResponseWriter with given status code.
 func Json(w http.ResponseWriter, status int, data interface{}) error {
 	if data == nil {
 		w.WriteHeader(status)

--- a/httpf/responses.go
+++ b/httpf/responses.go
@@ -1,0 +1,17 @@
+package httpf
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func Json(w http.ResponseWriter, status int, data interface{}) error {
+	v, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+
+	w.WriteHeader(status)
+	_, err = w.Write(v)
+	return err
+}

--- a/httpf/responses.go
+++ b/httpf/responses.go
@@ -6,6 +6,11 @@ import (
 )
 
 func Json(w http.ResponseWriter, status int, data interface{}) error {
+	if data == nil {
+		w.WriteHeader(status)
+		return nil
+	}
+
 	v, err := json.Marshal(data)
 	if err != nil {
 		return err

--- a/httpf/responses_test.go
+++ b/httpf/responses_test.go
@@ -1,0 +1,109 @@
+package httpf
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/Prastiwar/Go-flow/tests/assert"
+	"github.com/Prastiwar/Go-flow/tests/mocks"
+)
+
+func TestJson(t *testing.T) {
+	tests := []struct {
+		name      string
+		status    int
+		data      interface{}
+		writer    func(t *testing.T) http.ResponseWriter
+		assertion assert.ErrorFunc
+	}{
+		{
+			name:   "success",
+			status: 201,
+			data: struct {
+				Id string `json:"id"`
+			}{Id: "123"},
+			writer: func(t *testing.T) http.ResponseWriter {
+				writeCounter := assert.Count(t, 1)
+				writeHeaderCounter := assert.Count(t, 1)
+				m := &mocks.ResponseWriter{
+					OnHeader: func() http.Header {
+						t.Fatal("unexpected Header() function call")
+						return nil
+					},
+					OnWrite: func(b []byte) (int, error) {
+						assert.Equal(t, `{"id":"123"}`, string(b))
+						writeCounter.Inc()
+						return 0, nil
+					},
+					OnWriteHeader: func(code int) {
+						assert.Equal(t, 201, code)
+						writeHeaderCounter.Inc()
+					},
+				}
+				return m
+			},
+			assertion: func(t *testing.T, err error) {
+				assert.NilError(t, err)
+			},
+		},
+		{
+			name:   "success-nil-data",
+			status: 204,
+			data:   nil,
+			writer: func(t *testing.T) http.ResponseWriter {
+				writeHeaderCounter := assert.Count(t, 1)
+				m := &mocks.ResponseWriter{
+					OnHeader: func() http.Header {
+						t.Fatal("unexpected Header() function call")
+						return nil
+					},
+					OnWrite: func(b []byte) (int, error) {
+						t.Fatal("unexpected Write() function call")
+						return 0, nil
+					},
+					OnWriteHeader: func(code int) {
+						assert.Equal(t, 204, code)
+						writeHeaderCounter.Inc()
+					},
+				}
+				return m
+			},
+			assertion: func(t *testing.T, err error) {
+				assert.NilError(t, err)
+			},
+		},
+		{
+			name:   "invalid-pointer-data",
+			status: 204,
+			data:   &struct{ Chan chan (int) }{},
+			writer: func(t *testing.T) http.ResponseWriter {
+				m := &mocks.ResponseWriter{
+					OnHeader: func() http.Header {
+						t.Fatal("unexpected Header() function call")
+						return nil
+					},
+					OnWrite: func(b []byte) (int, error) {
+						t.Fatal("unexpected Write() function call")
+						return 0, nil
+					},
+					OnWriteHeader: func(code int) {
+						t.Fatal("unexpected Write() function call")
+					},
+				}
+				return m
+			},
+			assertion: func(t *testing.T, err error) {
+				assert.ErrorType(t, err, &json.UnsupportedTypeError{})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Json(tt.writer(t), tt.status, tt.data)
+
+			tt.assertion(t, err)
+		})
+	}
+}

--- a/httpf/router.go
+++ b/httpf/router.go
@@ -4,22 +4,41 @@ import (
 	"net/http"
 )
 
+// A ErrorHandler handles error returned from Handler
+//
+// Handle should write response to the ResponseWriter in common
+// used format with proper mapped error
 type ErrorHandler interface {
 	Handle(w http.ResponseWriter, r *http.Request, err error)
 }
 
+// The ErrorHandlerFunc type is an adapter to allow the use of ordinary
+// functions as Error handlers. If h is a function with
+// the appropriate signature, ErrorHandlerFunc(h) is a ErrorHandler that calls h.
 type ErrorHandlerFunc func(w http.ResponseWriter, r *http.Request, err error)
 
+// Handle calls h(w, r, err)
 func (h ErrorHandlerFunc) Handle(w http.ResponseWriter, r *http.Request, err error) {
 	h(w, r, err)
 }
 
+// A Router is an HTTP request multiplexer. It should match the URL of each incoming
+// request against a list of registered patterns and call the handler
+// for the pattern that most closely matches the URL.
+// Router also should take care of sanitizing the URL request path and the Host
+// header, stripping the port number and redirecting any request containing . or
+// .. elements or repeated slashes to an equivalent, cleaner URL.
 type Router interface {
 	http.Handler
 
 	Handle(pattern string, handler http.Handler)
 }
 
+// A RouteBuilder is convenient builder for routing registration. It defines
+// function for each HTTP Method. Pattern should be able to be registered with
+// any method. It's also responsible to use ErrorHandler and WriterDecorator in
+// mapping from Handler to http.Handler so errors can be handled gracefully and
+// http.ResponseWriter would be decorated with Response function.
 type RouteBuilder interface {
 	Get(pattern string, handler Handler) RouteBuilder
 	Post(pattern string, handler Handler) RouteBuilder

--- a/httpf/router.go
+++ b/httpf/router.go
@@ -1,0 +1,34 @@
+package httpf
+
+import (
+	"net/http"
+)
+
+type ErrorHandler interface {
+	Handle(w http.ResponseWriter, r *http.Request, err error)
+}
+
+type ErrorHandlerFunc func(w http.ResponseWriter, r *http.Request, err error)
+
+func (h ErrorHandlerFunc) Handle(w http.ResponseWriter, r *http.Request, err error) {
+	h(w, r, err)
+}
+
+type Router interface {
+	http.Handler
+
+	Handle(pattern string, handler http.Handler)
+}
+
+type RouteBuilder interface {
+	Get(pattern string, handler Handler) RouteBuilder
+	Post(pattern string, handler Handler) RouteBuilder
+	Put(pattern string, handler Handler) RouteBuilder
+	Delete(pattern string, handler Handler) RouteBuilder
+	Patch(pattern string, handler Handler) RouteBuilder
+	Options(pattern string, handler Handler) RouteBuilder
+
+	WithErrorHandler(handler ErrorHandler) RouteBuilder
+
+	Build() Router
+}

--- a/httpf/router.go
+++ b/httpf/router.go
@@ -49,6 +49,7 @@ type RouteBuilder interface {
 
 	WithErrorHandler(handler ErrorHandler) RouteBuilder
 	WithWriterDecorator(decorator func(http.ResponseWriter) ResponseWriter) RouteBuilder
+	WithParamsParser(parser ParamsParser) RouteBuilder
 
 	Build() Router
 }

--- a/httpf/router.go
+++ b/httpf/router.go
@@ -29,6 +29,7 @@ type RouteBuilder interface {
 	Options(pattern string, handler Handler) RouteBuilder
 
 	WithErrorHandler(handler ErrorHandler) RouteBuilder
+	WithWriterDecorator(decorator func(http.ResponseWriter) ResponseWriter) RouteBuilder
 
 	Build() Router
 }

--- a/httpf/server.go
+++ b/httpf/server.go
@@ -20,6 +20,7 @@ type Server interface {
 
 func NewServer(addr string, router Router) *http.Server {
 	return &http.Server{
+		Addr:    addr,
 		Handler: router,
 	}
 }

--- a/httpf/server.go
+++ b/httpf/server.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 )
 
+// A Server defines functionality for running an HTTP server.
 type Server interface {
 	Close() error
 	Shutdown(ctx context.Context) error
@@ -18,6 +19,7 @@ type Server interface {
 	ServeTLS(l net.Listener, certFile, keyFile string) error
 }
 
+// NewServer returns a new instance of Server
 func NewServer(addr string, router Router) *http.Server {
 	return &http.Server{
 		Addr:    addr,

--- a/httpf/server.go
+++ b/httpf/server.go
@@ -1,0 +1,25 @@
+package httpf
+
+import (
+	"context"
+	"net"
+	"net/http"
+)
+
+type Server interface {
+	Close() error
+	Shutdown(ctx context.Context) error
+	RegisterOnShutdown(f func())
+
+	ListenAndServe() error
+	Serve(l net.Listener) error
+
+	ListenAndServeTLS(certFile, keyFile string) error
+	ServeTLS(l net.Listener, certFile, keyFile string) error
+}
+
+func NewServer(addr string, router Router) *http.Server {
+	return &http.Server{
+		Handler: router,
+	}
+}

--- a/tests/assert/counter.go
+++ b/tests/assert/counter.go
@@ -8,6 +8,7 @@ import (
 type Counter struct {
 	expectedCount int
 	counter       int
+	atLeast       bool
 }
 
 // Count returns a Counter with expected n count to be asserted. Use Inc() to mark a call.
@@ -24,6 +25,12 @@ func Count(t *testing.T, n int, prefixes ...string) *Counter {
 	return c
 }
 
+// AtLeast marks counter to assert for at least count instead exact count and returns self.
+func (c *Counter) AtLeast() *Counter {
+	c.atLeast = true
+	return c
+}
+
 // Inc marks a single call to the function.
 func (c *Counter) Inc() {
 	c.counter++
@@ -32,6 +39,12 @@ func (c *Counter) Inc() {
 // Assert checks for count expectation.
 func (c *Counter) Assert(t *testing.T, prefixes ...string) {
 	t.Helper()
+	if c.atLeast {
+		if c.expectedCount > c.counter {
+			errorf(t, fmt.Sprintf("expected call count at least: '%v', actual: '%v'", c.expectedCount, c.counter), prefixes...)
+		}
+		return
+	}
 	if c.expectedCount != c.counter {
 		errorf(t, fmt.Sprintf("expected call count: '%v', actual: '%v'", c.expectedCount, c.counter), prefixes...)
 	}

--- a/tests/assert/counter.go
+++ b/tests/assert/counter.go
@@ -14,8 +14,10 @@ type Counter struct {
 // Assert() will be called on test cleanup, so it's not necessary to call it manually but recommended
 // due to convention to not hide any test side effects.
 func Count(t *testing.T, n int, prefixes ...string) *Counter {
+	t.Helper()
 	c := &Counter{expectedCount: n}
 	t.Cleanup(func() {
+		t.Helper()
 		c.Assert(t, prefixes...)
 	})
 

--- a/tests/assert/counter.go
+++ b/tests/assert/counter.go
@@ -29,6 +29,7 @@ func (c *Counter) Inc() {
 
 // Assert checks for count expectation.
 func (c *Counter) Assert(t *testing.T, prefixes ...string) {
+	t.Helper()
 	if c.expectedCount != c.counter {
 		errorf(t, fmt.Sprintf("expected call count: '%v', actual: '%v'", c.expectedCount, c.counter), prefixes...)
 	}

--- a/tests/assert/counter_test.go
+++ b/tests/assert/counter_test.go
@@ -39,6 +39,23 @@ func TestCounterAssert(t *testing.T) {
 			},
 			fail: true,
 		},
+		{
+			name: "at-least-assertion-with-more",
+			c: func(t *testing.T) *Counter {
+				c := Count(t, 1).AtLeast()
+				c.Inc()
+				c.Inc()
+				return c
+			},
+			fail: false,
+		},
+		{
+			name: "at-least-assertion-with-less",
+			c: func(t *testing.T) *Counter {
+				return Count(t, 1).AtLeast()
+			},
+			fail: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/tests/assert/equality.go
+++ b/tests/assert/equality.go
@@ -14,6 +14,7 @@ type ErrorFunc func(t *testing.T, err error)
 type ResultErrorFunc[T any] func(t *testing.T, result T, err error)
 
 func errorf(t *testing.T, msg string, prefixes ...string) {
+	t.Helper()
 	prefix := ""
 	if len(prefixes) > 0 {
 		prefix = strings.Join(prefixes, ": ") + ": "
@@ -23,31 +24,39 @@ func errorf(t *testing.T, msg string, prefixes ...string) {
 
 // Equal asserts expected and actual values are equal using deep equal from reflection
 func Equal(t *testing.T, expected interface{}, actual interface{}, prefixes ...string) {
+	t.Helper()
 	if !reflect.DeepEqual(expected, actual) {
+		if expected == nil && reflect.ValueOf(actual).IsNil() {
+			return
+		}
 		errorf(t, fmt.Sprintf("expected: '%v', actual: '%v'", expected, actual), prefixes...)
 	}
 }
 
 // Equal asserts expected and actual values are not equal using equal operator
 func NotEqual(t *testing.T, expected interface{}, actual interface{}, prefixes ...string) {
+	t.Helper()
 	if expected == actual {
 		errorf(t, fmt.Sprintf("expected: '%v', actual: '%v'", expected, actual), prefixes...)
 	}
 }
 
 func NotNil(t *testing.T, val interface{}, prefixes ...string) {
+	t.Helper()
 	if val == nil {
 		errorf(t, "expected not to be nil", prefixes...)
 	}
 }
 
 func NilError(t *testing.T, err error, prefixes ...string) {
+	t.Helper()
 	if err != nil {
 		errorf(t, fmt.Sprintf("expected error to be nil but was %v", err), prefixes...)
 	}
 }
 
 func Error(t *testing.T, err error, prefixes ...string) {
+	t.Helper()
 	if err == nil {
 		errorf(t, "expected error but got nil", prefixes...)
 	}
@@ -55,6 +64,7 @@ func Error(t *testing.T, err error, prefixes ...string) {
 
 // ErrorWith asserts err does contain target content within error string representation.
 func ErrorWith(t *testing.T, err error, content string, prefixes ...string) {
+	t.Helper()
 	errFormat := "expected error with content: '%v', error: '%v'"
 	if err == nil {
 		errorf(t, fmt.Sprintf(errFormat, content, err), prefixes...)
@@ -69,6 +79,7 @@ func ErrorWith(t *testing.T, err error, content string, prefixes ...string) {
 
 // ErrorIs asserts whether error in err's chain matches target.
 func ErrorIs(t *testing.T, err error, target error, prefixes ...string) {
+	t.Helper()
 	if !errors.Is(err, target) {
 		errorf(t, fmt.Sprintf("expected '%#v' error but got '%#v'", target, err), prefixes...)
 	}
@@ -76,6 +87,7 @@ func ErrorIs(t *testing.T, err error, target error, prefixes ...string) {
 
 // ErrorType matches just type of error.
 func ErrorType(t *testing.T, err error, target error, prefixes ...string) {
+	t.Helper()
 	if reflect.TypeOf(err) != reflect.TypeOf(target) {
 		errorf(t, fmt.Sprintf("expected '%#v' error but got '%#v'", target, err), prefixes...)
 	}
@@ -83,6 +95,7 @@ func ErrorType(t *testing.T, err error, target error, prefixes ...string) {
 
 // Approximately asserts actual duration is approximately(within delta difference) equal to expected duration.
 func Approximately(t *testing.T, expected time.Duration, actual time.Duration, delta time.Duration, prefixes ...string) {
+	t.Helper()
 	if expected < actual-delta || expected > actual+delta {
 		errorf(t, fmt.Sprintf("expected approximately '%v' duration but got '%v'", expected, actual), prefixes...)
 	}

--- a/tests/assert/equality_test.go
+++ b/tests/assert/equality_test.go
@@ -4,12 +4,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"reflect"
 	"testing"
 	"time"
 )
 
 func TestNotEqualAndEqual(t *testing.T) {
+	var pointer *http.Response
 	tests := []struct {
 		name     string
 		expected any
@@ -33,6 +35,12 @@ func TestNotEqualAndEqual(t *testing.T) {
 			expected: "test",
 			actual:   "test",
 			fails:    true,
+		},
+		{
+			name:     "interface-pointer-nil",
+			expected: nil,
+			actual:   pointer,
+			fails:    false,
 		},
 	}
 

--- a/tests/assert/maps.go
+++ b/tests/assert/maps.go
@@ -7,6 +7,7 @@ import (
 
 // MapMatch asserts all keys and corresponding values are applied to both map.
 func MapMatch[K comparable, V any](t *testing.T, mapA, mapB map[K]V, prefixes ...string) {
+	t.Helper()
 	if len(mapA) != len(mapB) {
 		errorf(t, fmt.Sprintf("expected same map length: mapA: '%v', mapB: '%v'", len(mapA), len(mapB)), prefixes...)
 	}
@@ -25,6 +26,7 @@ func MapMatch[K comparable, V any](t *testing.T, mapA, mapB map[K]V, prefixes ..
 
 // MapHas asserts that map contains specified key with equal value.
 func MapHas[K comparable, V any](t *testing.T, m map[K]V, key K, val V, prefixes ...string) {
+	t.Helper()
 	v, ok := m[key]
 	if !ok {
 		errorf(t, fmt.Sprintf("not found key: '%v'", key), prefixes...)

--- a/tests/assert/slices.go
+++ b/tests/assert/slices.go
@@ -10,6 +10,7 @@ import (
 // ElementsMatch asserts both slices have the same amount and equal elements. Any extra items
 // will be listed in error log.
 func ElementsMatch[T any](t *testing.T, arrA, arrB []T) {
+	t.Helper()
 	extraA, extraB := diffLists(arrA, arrB)
 
 	if len(extraA) == 0 && len(extraB) == 0 {

--- a/tests/mocks/cookiesJar.go
+++ b/tests/mocks/cookiesJar.go
@@ -1,0 +1,19 @@
+package mocks
+
+import (
+	"net/http"
+	"net/url"
+)
+
+type CookiesJar struct {
+	OnSetCookies func(u *url.URL, cookies []*http.Cookie)
+	OnCookies    func(u *url.URL) []*http.Cookie
+}
+
+func (j *CookiesJar) SetCookies(u *url.URL, cookies []*http.Cookie) {
+	j.OnSetCookies(u, cookies)
+}
+
+func (j *CookiesJar) Cookies(u *url.URL) []*http.Cookie {
+	return j.OnCookies(u)
+}

--- a/tests/mocks/responseWriter.go
+++ b/tests/mocks/responseWriter.go
@@ -8,14 +8,7 @@ type ResponseWriter struct {
 	OnHeader      func() http.Header
 	OnWrite       func([]byte) (int, error)
 	OnWriteHeader func(int)
-}
-
-func NewResponseWriter(header func() http.Header, write func([]byte) (int, error), writeHeader func(int)) *ResponseWriter {
-	return &ResponseWriter{
-		OnHeader:      header,
-		OnWrite:       write,
-		OnWriteHeader: writeHeader,
-	}
+	OnResponse    func(int, interface{}) error
 }
 
 func (w *ResponseWriter) Header() http.Header {
@@ -28,4 +21,8 @@ func (w *ResponseWriter) Write(b []byte) (int, error) {
 
 func (w *ResponseWriter) WriteHeader(statusCode int) {
 	w.OnWriteHeader(statusCode)
+}
+
+func (w *ResponseWriter) Response(code int, data interface{}) error {
+	return w.OnResponse(code, data)
 }

--- a/tests/mocks/responseWriter.go
+++ b/tests/mocks/responseWriter.go
@@ -1,0 +1,31 @@
+package mocks
+
+import (
+	"net/http"
+)
+
+type ResponseWriter struct {
+	OnHeader      func() http.Header
+	OnWrite       func([]byte) (int, error)
+	OnWriteHeader func(int)
+}
+
+func NewResponseWriter(header func() http.Header, write func([]byte) (int, error), writeHeader func(int)) *ResponseWriter {
+	return &ResponseWriter{
+		OnHeader:      header,
+		OnWrite:       write,
+		OnWriteHeader: writeHeader,
+	}
+}
+
+func (w *ResponseWriter) Header() http.Header {
+	return w.OnHeader()
+}
+
+func (w *ResponseWriter) Write(b []byte) (int, error) {
+	return w.OnWrite(b)
+}
+
+func (w *ResponseWriter) WriteHeader(statusCode int) {
+	w.OnWriteHeader(statusCode)
+}

--- a/tests/mocks/roundTripper.go
+++ b/tests/mocks/roundTripper.go
@@ -1,0 +1,13 @@
+package mocks
+
+import (
+	"net/http"
+)
+
+type RoundTripper struct {
+	OnRoundTrip func(*http.Request) (*http.Response, error)
+}
+
+func (rt *RoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	return rt.OnRoundTrip(r)
+}


### PR DESCRIPTION
<!-- Thanks for your contribution! Please read the https://github.com/Prastiwar/Go-Flow/blob/main/.github/CONTRIBUTING.md before submitting pull request to review -->

<!-- Link all the related issues or discussions with the changes or remove the placeholder links -->
[Related Issue](https://github.com/Prastiwar/Go-flow/issues/15)

<!-- Describe the scope of changes for this pull request -->
### Changes

- add client abstraction
- add router abstraction along with RouteBuilder
- add server abstraction
- add ParamsParser to allow router inject path params into request
- define handler interface which can return error
- extend ResponseWriter interface with  `Response(code int, data interface{}) error` function
- add consts with most common used headers
- use `t.Helper()` in assert package
- add `AtLeast()` to counter

<!-- Share with additional decisions you had to make or other implementation details, warnings, important information -->
### Notes

- The implementation can slightly differ than issued proposal, see `example_test.go` file to see code in action