### PR TITLE
[retry] Add context to retry execute

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 Framework for Go services in go with zero dependency rule, so you can use it in any project without other third-party dependencies or writing your own code for common tasks.
 
 - [Go-flow](#go-flow)
+  - [Production readiness](#production-readiness)
   - [Download](#download)
   - [Library purpose](#library-purpose)
   - [Packages](#packages)
@@ -25,6 +26,12 @@ Framework for Go services in go with zero dependency rule, so you can use it in 
     - [tests](#tests)
   - [Contributing](#contributing)
   - [License](#license)
+
+## Production readiness
+
+The library is in final phase before the stable version release. The phase consist of private project released to production. Though it can be already used in production until a stable v1 version release you should keep in mind that some breaking changes can still happen and will not increase the major version. Every breaking change will be noted either in the version release or pull request description.
+
+For release information see https://github.com/Prastiwar/Go-flow/discussions/27
 
 ## Download
 

--- a/policy/retry/example_test.go
+++ b/policy/retry/example_test.go
@@ -1,6 +1,7 @@
 package retry_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -17,7 +18,7 @@ func Example() {
 	)
 
 	startedTime := time.Now()
-	err := p.Execute(func() error {
+	err := p.Execute(context.Background(), func() error {
 		fmt.Println("executed after: " + time.Since(startedTime).Truncate(time.Second).String())
 		startedTime = time.Now()
 

--- a/policy/retry/policy_test.go
+++ b/policy/retry/policy_test.go
@@ -1,7 +1,9 @@
 package retry_test
 
 import (
+	"context"
 	"errors"
+	"strconv"
 	"testing"
 	"time"
 
@@ -16,7 +18,6 @@ func TestPolicy_Execute(t *testing.T) {
 		deltaDivider      = 2
 	)
 
-	var attempt int
 	var timeStart time.Time
 
 	withTwoAttemptsWaitAssertion := retry.WithCancelPredicate(func(attempt int, err error) bool {
@@ -40,12 +41,16 @@ func TestPolicy_Execute(t *testing.T) {
 
 	tests := []struct {
 		name     string
+		ctx      func(t *testing.T) context.Context
 		p        func(t *testing.T) retry.Policy
-		fn       func() error
-		asserter assert.ErrorFunc
+		fn       func(attempt int) error
+		asserter assert.ResultErrorFunc[int]
 	}{
 		{
 			name: "success-after-single-retry",
+			ctx: func(t *testing.T) context.Context {
+				return context.Background()
+			},
 			p: func(t *testing.T) retry.Policy {
 				c := assert.Count(t, 1, "failed retry call")
 				return retry.NewPolicy(
@@ -56,19 +61,22 @@ func TestPolicy_Execute(t *testing.T) {
 					}),
 				)
 			},
-			fn: func() error {
-				if attempt == 0 {
-					attempt++
+			fn: func(attempt int) error {
+				if attempt == 1 {
 					return errors.New("invalid")
 				}
 				return nil
 			},
-			asserter: func(t *testing.T, err error) {
+			asserter: func(t *testing.T, attempt int, err error) {
 				assert.NilError(t, err)
+				assert.Equal(t, attempt, 2)
 			},
 		},
 		{
 			name: "success-3-retries-cancel",
+			ctx: func(t *testing.T) context.Context {
+				return context.Background()
+			},
 			p: func(t *testing.T) retry.Policy {
 				c := assert.Count(t, 3, "failed retry call")
 				return retry.NewPolicy(
@@ -79,33 +87,119 @@ func TestPolicy_Execute(t *testing.T) {
 					}),
 				)
 			},
-			fn: func() error {
+			fn: func(attempt int) error {
 				return errors.New("invalid")
 			},
-			asserter: func(t *testing.T, err error) {
+			asserter: func(t *testing.T, attempt int, err error) {
 				assert.Error(t, err)
+				assert.Equal(t, attempt, 3)
 			},
 		},
 		{
 			name: "success-no-cancel-no-error",
+			ctx: func(t *testing.T) context.Context {
+				return context.Background()
+			},
 			p: func(t *testing.T) retry.Policy {
 				return retry.NewPolicy(
 					retry.WithCount(5),
 				)
 			},
-			fn: func() error {
+			fn: func(attempt int) error {
 				if attempt == 1 {
-					attempt++
 					return errors.New("invalid")
 				}
 				return nil
 			},
-			asserter: func(t *testing.T, err error) {
+			asserter: func(t *testing.T, attempt int, err error) {
 				assert.NilError(t, err)
+				assert.Equal(t, attempt, 2)
+			},
+		},
+		{
+			name: "success-no-cancel-no-error-no-context",
+			ctx: func(t *testing.T) context.Context {
+				return nil
+			},
+			p: func(t *testing.T) retry.Policy {
+				return retry.NewPolicy(
+					retry.WithCount(5),
+					retry.WithWaitTimes(firstAttemptTime, secondAttemptTime),
+				)
+			},
+			fn: func(attempt int) error {
+				if attempt == 1 {
+					return errors.New("invalid")
+				}
+				return nil
+			},
+			asserter: func(t *testing.T, attempt int, err error) {
+				assert.NilError(t, err)
+				assert.Equal(t, attempt, 2)
+			},
+		},
+		{
+			name: "success-context-canceled",
+			ctx: func(t *testing.T) context.Context {
+				return canceledContext()
+			},
+			p: func(t *testing.T) retry.Policy {
+				return retry.NewPolicy(
+					retry.WithCount(3),
+					retry.WithWaitTimes(firstAttemptTime, secondAttemptTime),
+				)
+			},
+			fn: func(attempt int) error {
+				return errors.New("invalid")
+			},
+			asserter: func(t *testing.T, attempt int, err error) {
+				assert.ErrorIs(t, err, context.Canceled)
+				assert.Equal(t, attempt, 1)
+			},
+		},
+		{
+			name: "success-context-canceled-in-meanwhile",
+			ctx: func(t *testing.T) context.Context {
+				return delayCancelContext(secondAttemptTime)
+			},
+			p: func(t *testing.T) retry.Policy {
+				return retry.NewPolicy(
+					retry.WithCount(3),
+					retry.WithWaitTimes(firstAttemptTime, secondAttemptTime),
+				)
+			},
+			fn: func(attempt int) error {
+				return errors.New("invalid")
+			},
+			asserter: func(t *testing.T, attempt int, err error) {
+				assert.ErrorIs(t, err, context.Canceled)
+				assert.Equal(t, true, attempt >= 2, "invalid attempt value", strconv.Itoa(attempt))
+			},
+		},
+		{
+			name: "success-context-deadline-exceeded",
+			ctx: func(t *testing.T) context.Context {
+				return deadlinedContext()
+			},
+			p: func(t *testing.T) retry.Policy {
+				return retry.NewPolicy(
+					retry.WithCount(3),
+					retry.WithWaitTimes(firstAttemptTime, secondAttemptTime),
+				)
+			},
+			fn: func(attempt int) error {
+				return errors.New("invalid")
+			},
+			asserter: func(t *testing.T, attempt int, err error) {
+				assert.ErrorIs(t, err, context.DeadlineExceeded)
+				assert.Equal(t, attempt, 1)
 			},
 		},
 		{
 			name: "success-wait-times",
+			ctx: func(t *testing.T) context.Context {
+				return context.Background()
+			},
 			p: func(t *testing.T) retry.Policy {
 				return retry.NewPolicy(
 					retry.WithCount(3),
@@ -113,15 +207,19 @@ func TestPolicy_Execute(t *testing.T) {
 					withTwoAttemptsWaitAssertion,
 				)
 			},
-			fn: func() error {
+			fn: func(attempt int) error {
 				return errors.New("invalid")
 			},
-			asserter: func(t *testing.T, err error) {
+			asserter: func(t *testing.T, attempt int, err error) {
 				assert.Error(t, err)
+				assert.Equal(t, attempt, 4)
 			},
 		},
 		{
 			name: "success-waiter",
+			ctx: func(t *testing.T) context.Context {
+				return context.Background()
+			},
 			p: func(t *testing.T) retry.Policy {
 				return retry.NewPolicy(
 					retry.WithCount(3),
@@ -139,37 +237,66 @@ func TestPolicy_Execute(t *testing.T) {
 					withTwoAttemptsWaitAssertion,
 				)
 			},
-			fn: func() error {
+			fn: func(attempt int) error {
 				return errors.New("invalid")
 			},
-			asserter: func(t *testing.T, err error) {
+			asserter: func(t *testing.T, attempt int, err error) {
 				assert.Error(t, err)
+				assert.Equal(t, attempt, 4)
 			},
 		},
 		{
 			name: "success-default-cancel",
+			ctx: func(t *testing.T) context.Context {
+				return context.Background()
+			},
 			p: func(t *testing.T) retry.Policy {
 				return retry.NewPolicy(
 					retry.WithCount(1),
 				)
 			},
-			fn: func() error {
+			fn: func(attempt int) error {
 				return errors.New("invalid")
 			},
-			asserter: func(t *testing.T, err error) {
+			asserter: func(t *testing.T, attempt int, err error) {
 				assert.Error(t, err)
+				assert.Equal(t, attempt, 2)
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			attempt = 0
+			zero := 0
+			attempt := &zero
 			p := tt.p(t)
 
-			err := p.Execute(tt.fn)
+			err := p.Execute(tt.ctx(t), func() error {
+				*attempt++
+				return tt.fn(*attempt)
+			})
 
-			tt.asserter(t, err)
+			tt.asserter(t, *attempt, err)
 		})
 	}
+}
+
+func delayCancelContext(delay time.Duration) context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+	time.AfterFunc(delay, func() {
+		cancel()
+	})
+	return ctx
+}
+
+func canceledContext() context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	return ctx
+}
+
+func deadlinedContext() context.Context {
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now())
+	cancel()
+	return ctx
 }

--- a/tests/mocks/retry.go
+++ b/tests/mocks/retry.go
@@ -1,6 +1,8 @@
 package mocks
 
 import (
+	"context"
+
 	"github.com/Prastiwar/Go-flow/policy/retry"
 	"github.com/Prastiwar/Go-flow/tests/assert"
 )
@@ -8,10 +10,10 @@ import (
 var _ retry.Policy = RetryPolicyMock{}
 
 type RetryPolicyMock struct {
-	OnExecute func(fn func() error) error
+	OnExecute func(ctx context.Context, fn func() error) error
 }
 
-func (m RetryPolicyMock) Execute(fn func() error) error {
+func (m RetryPolicyMock) Execute(ctx context.Context, fn func() error) error {
 	assert.ExpectCall(m.OnExecute)
-	return m.OnExecute(fn)
+	return m.OnExecute(ctx, fn)
 }


### PR DESCRIPTION
<!-- Describe the scope of changes for this pull request -->
### Changes

- add `Production readiness` section in `README.md`
- change retry.Policy.Execute definition from `Execute(fn func() error) error` to `Execute(ctx context.Context, fn func() error) error`
- refactor retry tests

<!-- Share with additional decisions you had to make or other implementation details, warnings, important information -->
### Notes

- This allows to better handle context synchronization and easier API for mechanism like graceful shutdown while using retry.
- **This is breaking change**
