### PR TITLE
Add BodyUnmarshaler to httpf

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ See [example file](middleware/example_test.go) for runnable examples.
 
 ### policy
 
-Defines policies that could help developers to handle gracefully faults like retry.
+Defines policies that could help developers to handle gracefully faults like retry or any other resilience functionality.
 
 #### retry
 
@@ -124,6 +124,8 @@ See [example file](policy/retry/example_test.go) for runnable retry policy examp
 
 Rate package introduces dependency inversion over third-party rate-limit libraries. In case the third party does not follow the contract your infrastructure should implement an adapter for this specific library to fulfill Limiter interfaces.
 Package contains simple and unified API that can be implemented by any algorithm like token/leaky bucket, fixed/sliding window, and others. There are a few interfaces that extend the standard Limiter interface like BurstLimiter which supports bursting or ReservationLimiter which supports token reservation.
+
+See [example file](rate/example_test.go) for runnable rate examples.
 
 ### reflection
 

--- a/httpf/body.go
+++ b/httpf/body.go
@@ -1,0 +1,57 @@
+package httpf
+
+import (
+	"net/http"
+
+	"github.com/Prastiwar/Go-flow/datas"
+)
+
+var (
+	_ BodyUnmarshaler = &bodyUnmarshaler{}
+)
+
+// BodyUnmarshaler is an interface that defines a method to unmarshal the body of an HTTP response into a value of any type.
+// The implementation of this interface should handle the cases where the response status code indicates an error and return an appropriate error value.
+type BodyUnmarshaler interface {
+	Unmarshal(r *http.Response, v any) error
+}
+
+type bodyUnmarshaler struct {
+	errorHandler func(r *http.Response, u datas.ReaderUnmarshaler) error
+	unmarshaler  datas.ReaderUnmarshaler
+}
+
+// NewBodyUnmarshaler returns an implementation for BodyUnmarshaler which unmarshals response body and supports error handling.
+// Passed unmarshaler will be used to unmarshal both, actual body value or error value from body response.
+// If IsErrorStatus will return true during Unmarshal, it will call the errorHandler to transform error or handle it.
+func NewBodyUnmarshaler(u datas.ReaderUnmarshaler, errorHandler func(r *http.Response, u datas.ReaderUnmarshaler) error) BodyUnmarshaler {
+	return &bodyUnmarshaler{
+		errorHandler: errorHandler,
+		unmarshaler:  u,
+	}
+}
+
+// NewBodyUnmarshalerWithError returns an implementation for BodyUnmarshaler which unmarshals response body and supports http error unmarshaling.
+// Passed unmarshaler will be used to unmarshal both, actual body value or error value from body response.
+// errorStruct must be a pointer to error struct which indicates structure of the error returned from API in body response.
+// If IsErrorStatus will return true during Unmarshal, it will copy errorStruct and unmarshal error response into copied value and return it.
+// If custom error handling e.g for 404 codes is needed, you should use NewBodyUnmarshaler.
+func NewBodyUnmarshalerWithError(u datas.ReaderUnmarshaler, errorStruct error) BodyUnmarshaler {
+	return NewBodyUnmarshaler(u, func(r *http.Response, u datas.ReaderUnmarshaler) error {
+		var httpError = errorStruct
+		if err := u.UnmarshalFrom(r.Body, &httpError); err != nil {
+			return err
+		}
+		return httpError
+	})
+}
+
+func (u *bodyUnmarshaler) Unmarshal(r *http.Response, v any) error {
+	defer r.Body.Close()
+
+	if IsErrorStatus(r.StatusCode) {
+		return u.errorHandler(r, u.unmarshaler)
+	}
+
+	return u.unmarshaler.UnmarshalFrom(r.Body, v)
+}

--- a/httpf/body_test.go
+++ b/httpf/body_test.go
@@ -1,0 +1,99 @@
+package httpf_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/Prastiwar/Go-flow/datas"
+	"github.com/Prastiwar/Go-flow/httpf"
+	"github.com/Prastiwar/Go-flow/tests/assert"
+)
+
+type nameStructFixture struct {
+	Name string `json:"name"`
+}
+
+type httpErrorFixture struct {
+	Message string `json:"message"`
+}
+
+func (err *httpErrorFixture) Error() string {
+	return err.Message
+}
+
+func TestBodyUnmarshaler(t *testing.T) {
+	tests := []struct {
+		name      string
+		u         httpf.BodyUnmarshaler
+		r         http.Response
+		v         any
+		assertion assert.ResultErrorFunc[any]
+	}{
+		{
+			name: "handle-200-status-with-json",
+			u: httpf.NewBodyUnmarshaler(datas.Json(), func(r *http.Response, u datas.ReaderUnmarshaler) error {
+				panic("unexpected call")
+			}),
+			r: http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewBufferString(`{"name":"foo"}`)),
+			},
+			v: &nameStructFixture{},
+			assertion: func(t *testing.T, result any, err error) {
+				assert.NilError(t, err)
+				v, ok := result.(*nameStructFixture)
+				assert.Equal(t, true, ok)
+				assert.Equal(t, "foo", v.Name)
+			},
+		},
+		{
+			name: "handle-404-status-custom-error",
+			u: httpf.NewBodyUnmarshaler(datas.Json(), func(r *http.Response, u datas.ReaderUnmarshaler) error {
+				if r.StatusCode == http.StatusNotFound {
+					return errors.New("not-found")
+				}
+				return errors.New("invalid-status")
+			}),
+			r: http.Response{
+				StatusCode: http.StatusNotFound,
+				Body:       io.NopCloser(nil),
+			},
+			assertion: func(t *testing.T, result any, err error) {
+				assert.ErrorWith(t, err, "not-found")
+			},
+		},
+		{
+			name: "error-404-status-with-struct",
+			u:    httpf.NewBodyUnmarshalerWithError(datas.Json(), &httpErrorFixture{}),
+			r: http.Response{
+				StatusCode: http.StatusNotFound,
+				Body:       io.NopCloser(bytes.NewBufferString(`{"message":"resource-not-found"}`)),
+			},
+			assertion: func(t *testing.T, result any, err error) {
+				assert.ErrorType(t, err, &httpErrorFixture{})
+				assert.Equal(t, "resource-not-found", err.Error())
+			},
+		},
+		{
+			name: "error-400-status-with-invalid-json-body",
+			u:    httpf.NewBodyUnmarshalerWithError(datas.Json(), &httpErrorFixture{}),
+			r: http.Response{
+				StatusCode: http.StatusBadRequest,
+				Body:       io.NopCloser(bytes.NewBufferString(`{`)),
+			},
+			assertion: func(t *testing.T, result any, err error) {
+				assert.ErrorIs(t, err, io.ErrUnexpectedEOF)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.u.Unmarshal(&tt.r, tt.v)
+			tt.assertion(t, tt.v, err)
+		})
+	}
+}

--- a/httpf/responses.go
+++ b/httpf/responses.go
@@ -19,3 +19,8 @@ func Json(w http.ResponseWriter, status int, data interface{}) error {
 	_, err = w.Write(v)
 	return err
 }
+
+// IsErrorStatus returns true if status code is greater or equal than 400 and less than 600.
+func IsErrorStatus(code int) bool {
+	return code >= 400 && code < 600
+}

--- a/tests/mocks/httpf.go
+++ b/tests/mocks/httpf.go
@@ -12,12 +12,13 @@ import (
 )
 
 var (
-	_ httpf.Client         = ClientMock{}
-	_ httpf.ResponseWriter = HttpfResponseWriterMock{}
-	_ httpf.ParamsParser   = ParamsParserMock{}
-	_ httpf.Router         = RouterMock{}
-	_ httpf.RouteBuilder   = RouteBuilderMock{}
-	_ httpf.Server         = ServerMock{}
+	_ httpf.Client          = ClientMock{}
+	_ httpf.ResponseWriter  = HttpfResponseWriterMock{}
+	_ httpf.ParamsParser    = ParamsParserMock{}
+	_ httpf.Router          = RouterMock{}
+	_ httpf.RouteBuilder    = RouteBuilderMock{}
+	_ httpf.Server          = ServerMock{}
+	_ httpf.BodyUnmarshaler = BodyUnmarshalerMock{}
 )
 
 type ClientMock struct {
@@ -222,4 +223,13 @@ func (m ServerMock) ServeTLS(l net.Listener, certFile string, keyFile string) er
 func (m ServerMock) Shutdown(ctx context.Context) error {
 	assert.ExpectCall(m.OnShutdown)
 	return m.OnShutdown(ctx)
+}
+
+type BodyUnmarshalerMock struct {
+	OnUnmarshal func(r *http.Response, v any) error
+}
+
+func (m BodyUnmarshalerMock) Unmarshal(r *http.Response, v any) error {
+	assert.ExpectCall(m.OnUnmarshal)
+	return m.OnUnmarshal(r, v)
 }


### PR DESCRIPTION
<!-- Describe the scope of changes for this pull request -->
### Changes

#### Features

- `BodyUnmarshaler` interface for handling the response body data
- add general implementation for `BodyUnmarshaler` with 2 constructors `NewBodyUnmarshaler` with custom error handler and  `NewBodyUnmarshalerWithError` which uses error pointer to define error structure and forward it
- add `IsErrorStatus` to indicate if status is success or failure

#### Fixes

- Update Readme with example_file.go link to rate package

<!-- Share with additional decisions you had to make or other implementation details, warnings, important information -->
### Notes

-
