### PR TITLE
Fix reflection cast As

### DIFF
--- a/.github/ISSUE_TEMPLATE/general-issue.md
+++ b/.github/ISSUE_TEMPLATE/general-issue.md
@@ -8,7 +8,7 @@ assignees: ''
 
 ---
 
-<!--- Provide a more detailed introduction to the issue itself, why is is a problem -->
+<!--- Provide a more detailed introduction to the issue itself, why is it a problem -->
 ## Description
 
 -

--- a/reflection/cast/casting.go
+++ b/reflection/cast/casting.go
@@ -2,8 +2,14 @@
 // It includes casting between different (castable)types for slice.
 package cast
 
+import (
+	"reflect"
+
+	"github.com/Prastiwar/Go-flow/reflection"
+)
+
 // As creates new slice instance and casts from elements to result slice.
-// It will return true when from slice is empty.
+// It reports true when from slice is empty.
 func As[R any, T any](from []T) ([]R, bool) {
 	count := len(from)
 	result := make([]R, count)
@@ -13,9 +19,55 @@ func As[R any, T any](from []T) ([]R, bool) {
 		case R:
 			result[i] = R(t)
 		default:
-			return nil, false
+			var r R
+			targetType := reflect.TypeOf(r)
+			actualValue := reflect.ValueOf(from[i])
+
+			castedValue, ok := reflection.CastFieldValue(targetType, actualValue)
+			if !ok {
+				return nil, false
+			}
+
+			resultVal, ok := castedValue.Interface().(R)
+			if !ok {
+				return nil, false
+			}
+
+			result[i] = resultVal
 		}
 	}
 
+	return result, true
+}
+
+// Parse creates new slice instance and casts, converts or parses from elements to result slice.
+// It reports true when from slice is empty or false if there was any error during parsing.
+//
+// NOTE: conversion from untyped int to string yields a string of one rune, not a string of digits.
+func Parse[R any, T any](from []T) ([]R, bool) {
+	result, ok := As[R](from)
+	if ok {
+		return result, true
+	}
+
+	count := len(from)
+	result = make([]R, count)
+
+	for i := 0; i < count; i++ {
+		var r R
+		targetType := reflect.TypeOf(r)
+		actualValue := reflect.ValueOf(from[i])
+		val, err := reflection.GetFieldValueFor(targetType, actualValue)
+		if err != nil {
+			return nil, false
+		}
+
+		resultVal, ok := val.Interface().(R)
+		if !ok {
+			return nil, false
+		}
+
+		result[i] = resultVal
+	}
 	return result, true
 }

--- a/reflection/cast/casting_test.go
+++ b/reflection/cast/casting_test.go
@@ -1,6 +1,7 @@
 package cast_test
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/Prastiwar/Go-flow/reflection/cast"
@@ -9,7 +10,9 @@ import (
 
 type customString string
 
-func TestAsString(t *testing.T) {
+type customCustomString customString
+
+func TestAsIntToString(t *testing.T) {
 	arr := []interface{}{"1", "2", "3"}
 
 	r, ok := cast.As[string](arr)
@@ -21,10 +24,69 @@ func TestAsString(t *testing.T) {
 	}
 }
 
-func TestAsInvalid(t *testing.T) {
+func TestAsCustomString(t *testing.T) {
 	arr := []customString{"1", "2", "3"}
 
 	r, ok := cast.As[string](arr)
+
+	assert.Equal(t, true, ok)
+	assert.Equal(t, len(arr), len(r))
+	for i := 0; i < len(arr); i++ {
+		assert.Equal(t, string(arr[i]), r[i])
+	}
+}
+
+func TestAsCustomCustomString(t *testing.T) {
+	arr := []customCustomString{"1", "2", "3"}
+
+	r, ok := cast.As[customString](arr)
+
+	assert.Equal(t, true, ok)
+	assert.Equal(t, len(arr), len(r))
+	for i := 0; i < len(arr); i++ {
+		assert.Equal(t, customString(arr[i]), r[i])
+	}
+}
+
+func TestAsInvalid(t *testing.T) {
+	arr := []interface{}{1, 2, 3}
+
+	r, ok := cast.As[struct{}](arr)
+
+	assert.Equal(t, false, ok)
+	assert.Equal(t, 0, len(r))
+}
+
+func TestParseStringToInt(t *testing.T) {
+	arr := []string{"1", "2", "3"}
+
+	r, ok := cast.Parse[int32](arr)
+
+	assert.Equal(t, true, ok)
+	assert.Equal(t, len(arr), len(r))
+	for i := 0; i < len(arr); i++ {
+		v, err := strconv.Atoi(arr[i])
+		assert.NilError(t, err)
+		assert.Equal(t, int32(v), r[i])
+	}
+}
+
+func TestParseIntToString(t *testing.T) {
+	arr := []int32{1, 2, 3}
+
+	r, ok := cast.Parse[string](arr)
+
+	assert.Equal(t, true, ok)
+	assert.Equal(t, len(arr), len(r))
+	for i := 0; i < len(arr); i++ {
+		assert.Equal(t, string(arr[i]), r[i])
+	}
+}
+
+func TestParseInvalid(t *testing.T) {
+	arr := []int32{1, 2, 3}
+
+	r, ok := cast.Parse[struct{}](arr)
 
 	assert.Equal(t, false, ok)
 	assert.Equal(t, 0, len(r))

--- a/reflection/cast/example_test.go
+++ b/reflection/cast/example_test.go
@@ -18,3 +18,16 @@ func ExampleAs() {
 	// Output:
 	// [1 2 3]
 }
+
+func ExampleParse() {
+	arr := []interface{}{"1", "2", "3"}
+
+	stringArr, ok := cast.Parse[int32](arr)
+	if !ok {
+		panic("cannot parse between provided two types")
+	}
+	fmt.Println(stringArr)
+
+	// Output:
+	// [1 2 3]
+}

--- a/reflection/fields_test.go
+++ b/reflection/fields_test.go
@@ -8,6 +8,10 @@ import (
 	"github.com/Prastiwar/Go-flow/tests/assert"
 )
 
+func ptr[T any](v T) *T {
+	return &v
+}
+
 func TestSetFieldValue(t *testing.T) {
 	var nilBool *bool
 	tests := []struct {
@@ -237,6 +241,25 @@ func TestGetFieldValueFor(t *testing.T) {
 	}
 }
 
-func ptr[T any](v T) *T {
-	return &v
-}
+// func TestCastFieldValue(t *testing.T) {
+// 	tests := []struct {
+// 		name      string
+// 		fieldType reflect.Type
+// 		rawValue  any
+// 		want      reflect.Value
+// 		want1     bool
+// 	}{
+// 		// TODO: Add test cases.
+// 	}
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			got, err := reflection.CastFieldValue(tt.args.fieldType, tt.args.rawValue)
+// 			if !reflect.DeepEqual(got, tt.want) {
+// 				t.Errorf("CastFieldValue() got = %v, want %v", got, tt.want)
+// 			}
+// 			if got1 != tt.want1 {
+// 				t.Errorf("CastFieldValue() got1 = %v, want %v", got1, tt.want1)
+// 			}
+// 		})
+// 	}
+// }

--- a/tests/assert/mocking.go
+++ b/tests/assert/mocking.go
@@ -8,7 +8,7 @@ import (
 )
 
 // ExpectCall panics with unexpected call message for caller name if fn is nil. If fn is not
-// a func then it will panic with invalid parameter message. Staandard way to call this is:
+// a func then it will panic with invalid parameter message. Standard way to call this is:
 //
 //	func (m MyMock) Do(key string) error {
 //		assert.ExpectCall(m.OnDo) // if m.OnDo is nil - it will panic with accurate message


### PR DESCRIPTION
<!-- Describe the scope of changes for this pull request -->
### Changes

- `cast.As` now reports true and correctly casts values if a type definition has the same underlying type (like named types)
- `cast.Parse` added for a more parsable version of casting (converting) with arrays
- `CastFieldValue` added for reflection helper similar to cast.As for reflect.Value

<!-- Share with additional decisions you had to make or other implementation details, warnings, important information -->
### Notes

-
