### PR TITLE
Add context to Load

### DIFF
--- a/config/envProvider.go
+++ b/config/envProvider.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"os"
 )
 
@@ -24,7 +25,7 @@ func NewEnvProviderWith(prefix string) *envProvider {
 
 // Load lookups os environment variables for each field name from v value and store result in matching v field.
 // If there is no matching field it will be ignored and it's value will not be overridden.
-func (p *envProvider) Load(v any, opts ...LoadOption) (err error) {
+func (p *envProvider) Load(ctx context.Context, v any, opts ...LoadOption) (err error) {
 	options := NewLoadOptions(opts...)
 	setter := NewFieldSetter(EnvProviderName, *options)
 

--- a/config/envProvider_test.go
+++ b/config/envProvider_test.go
@@ -1,6 +1,7 @@
 package config_test
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -122,7 +123,7 @@ func TestEnvProviderLoad(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			p := config.NewEnvProviderWith(tt.prefix)
 			v, asserts := tt.init(t)
-			err := p.Load(v)
+			err := p.Load(context.Background(), v)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {

--- a/config/example_test.go
+++ b/config/example_test.go
@@ -1,6 +1,7 @@
 package config_test
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"strings"
@@ -62,7 +63,7 @@ func Example() {
 	// dbOptions will be loaded starting from the first passed provider up to the last one.
 	// All values will be also overridden by each provider in this order.
 	// The default value is not overridden by provider if it doesn't exist in it.
-	err = cfg.Load(&dbOptions)
+	err = cfg.Load(context.Background(), &dbOptions)
 	if err != nil {
 		// One of the providers failed to load config values
 		panic(err)

--- a/config/flagProvider.go
+++ b/config/flagProvider.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"flag"
 	"os"
 )
@@ -29,7 +30,7 @@ func NewFlagProvider(flags ...flag.Flag) *flagProvider {
 // Load parses flag definitions from the argument list, which should not include the command name.
 // Parsed flag value results are stored in matching v fields. If there is no matching field it
 // will be ignored and it's value will not be overridden.
-func (p *flagProvider) Load(v any, opts ...LoadOption) error {
+func (p *flagProvider) Load(ctx context.Context, v any, opts ...LoadOption) error {
 	err := p.set.Parse(os.Args[1:])
 	if err != nil {
 		return err

--- a/config/flagProvider_test.go
+++ b/config/flagProvider_test.go
@@ -1,6 +1,7 @@
 package config_test
 
 import (
+	"context"
 	"flag"
 	"os"
 	"reflect"
@@ -197,7 +198,7 @@ func TestFlagProviderLoad(t *testing.T) {
 			p := config.NewFlagProvider(tt.flags...)
 			v, asserts := tt.init(t)
 
-			err := p.Load(v, tt.options...)
+			err := p.Load(context.Background(), v, tt.options...)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {

--- a/config/readerProvider.go
+++ b/config/readerProvider.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"io"
 	"os"
 
@@ -23,7 +24,7 @@ func NewReaderProvider(r io.Reader, d datas.ReaderUnmarshaler) *readerProvider {
 // Load parses flag definitions from the argument list, which should not include the command name.
 // Parsed flag value results are stored in matching v fields. If there is no matching field it
 // will be ignored and it's value will not be overridden.
-func (p *readerProvider) Load(v any, opts ...LoadOption) error {
+func (p *readerProvider) Load(ctx context.Context, v any, opts ...LoadOption) error {
 	return p.decoder.UnmarshalFrom(p.reader, v)
 }
 

--- a/config/readerProvider_test.go
+++ b/config/readerProvider_test.go
@@ -1,6 +1,7 @@
 package config_test
 
 import (
+	"context"
 	"os"
 	"strings"
 	"testing"
@@ -60,13 +61,30 @@ func TestReaderProviderLoad(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "inaccesible-file-reader",
+			init: func(t *testing.T) (config.Provider, any, func()) {
+				provider := config.NewFileProvider("unknown", datas.Json())
+
+				v := struct {
+					Title string
+				}{
+					Title: "unchanged",
+				}
+
+				return provider, &v, func() {
+					assert.Equal(t, "unchanged", v.Title)
+				}
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			provider, v, asserts := tt.init(t)
 
-			err := provider.Load(v)
+			err := provider.Load(context.Background(), v)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {

--- a/config/source_test.go
+++ b/config/source_test.go
@@ -1,6 +1,7 @@
 package config_test
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"os"
@@ -279,7 +280,7 @@ func TestSourceLoad(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			source, v, asserts := tt.init(t)
 
-			err := source.Load(v, tt.opts...)
+			err := source.Load(context.Background(), v, tt.opts...)
 
 			asserts(err)
 		})

--- a/tests/mocks/config.go
+++ b/tests/mocks/config.go
@@ -1,6 +1,8 @@
 package mocks
 
 import (
+	"context"
+
 	"github.com/Prastiwar/Go-flow/config"
 	"github.com/Prastiwar/Go-flow/tests/assert"
 )
@@ -10,10 +12,10 @@ var (
 )
 
 type ProviderMock struct {
-	OnLoad func(v any, opts ...config.LoadOption) error
+	OnLoad func(ctx context.Context, v any, opts ...config.LoadOption) error
 }
 
-func (m ProviderMock) Load(v any, opts ...config.LoadOption) error {
+func (m ProviderMock) Load(ctx context.Context, v any, opts ...config.LoadOption) error {
 	assert.ExpectCall(m.OnLoad)
-	return m.OnLoad(v, opts...)
+	return m.OnLoad(ctx, v, opts...)
 }


### PR DESCRIPTION
<!-- Describe the scope of changes for this pull request -->
### Changes

- add `ctx context.Context` to `config.Provider.Load` signature
- add unit test for config.ReaderProvider for open file failure case

<!-- Share with additional decisions you had to make or other implementation details, warnings, important information -->
### Notes

- Now the provider interface support loading external sources e.g over HTTP protocol with cancellation
