### PR TITLE
Fix httpf flaky tests, update go workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,9 +8,18 @@ on:
 
 env:
   CI: true
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
 jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    if: startsWith(github.head_ref || github.ref_name, 'docs/') == false
+    steps:
+      - name: Trigger
+        run: echo trigger jobs at ${{ env.BRANCH_NAME }} branch
+
   build:
+    needs: trigger
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -35,6 +44,7 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    needs: trigger
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3

--- a/httpf/server_test.go
+++ b/httpf/server_test.go
@@ -1,0 +1,16 @@
+package httpf_test
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/Prastiwar/Go-flow/httpf"
+	"github.com/Prastiwar/Go-flow/tests/assert"
+)
+
+func TestNewServer(t *testing.T) {
+	got := httpf.NewServer("localhost:8086", nil)
+
+	assert.Equal(t, reflect.TypeOf(&http.Server{}), reflect.TypeOf(got))
+}


### PR DESCRIPTION
### Changes

- fix flaky tests using runServer function which runs the HTTP server
- ignore go github workflow for `docs/` branch pull requests

<!-- Share with additional decisions you had to make or other implementation details, warnings, important information -->
### Notes

-
