### PR TITLE
Improve defensiveness in memory limiter ctor

### DIFF
--- a/httpf/handler.go
+++ b/httpf/handler.go
@@ -1,6 +1,10 @@
 package httpf
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/Prastiwar/Go-flow/exception"
+)
 
 // A ResponseWriter interface is used by an HTTP handler to
 // construct an HTTP response. It extends http.ResponseWriter with
@@ -39,4 +43,14 @@ type HandlerFunc func(w ResponseWriter, r *http.Request) error
 // ServeHTTP calls h(w, r).
 func (h HandlerFunc) ServeHTTP(w ResponseWriter, r *http.Request) error {
 	return h(w, r)
+}
+
+// RecoverMiddleware returns httpf.Handler which uses recover feature to return an error in case of panic.
+func RecoverMiddleware(h Handler) Handler {
+	return HandlerFunc(func(w ResponseWriter, r *http.Request) (retErr error) {
+		defer exception.HandlePanicError(func(err error) {
+			retErr = err
+		})
+		return h.ServeHTTP(w, r)
+	})
 }

--- a/httpf/handler_test.go
+++ b/httpf/handler_test.go
@@ -1,0 +1,40 @@
+package httpf
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/Prastiwar/Go-flow/exception"
+	"github.com/Prastiwar/Go-flow/tests/assert"
+)
+
+func TestRecoverMiddleware(t *testing.T) {
+	t.Run("with-panic", func(t *testing.T) {
+		defer exception.HandlePanicError(func(err error) {
+			assert.NilError(t, err)
+		})
+
+		got := RecoverMiddleware(HandlerFunc(func(w ResponseWriter, r *http.Request) error {
+			panic("panic-message")
+		}))
+
+		err := got.ServeHTTP(nil, nil)
+
+		assert.ErrorWith(t, err, "panic-message")
+	})
+
+	t.Run("with-no-panic", func(t *testing.T) {
+		defer exception.HandlePanicError(func(err error) {
+			assert.NilError(t, err)
+		})
+
+		got := RecoverMiddleware(HandlerFunc(func(w ResponseWriter, r *http.Request) error {
+			return errors.New("no-panic-error")
+		}))
+
+		err := got.ServeHTTP(nil, nil)
+
+		assert.ErrorWith(t, err, "no-panic-error")
+	})
+}

--- a/httpf/rate.go
+++ b/httpf/rate.go
@@ -59,7 +59,7 @@ func PathRateKey() RateHttpKeyFactory {
 // merge the keys into single string key using whitespace as separator.
 func ComposeRateKeyFactories(factories ...RateHttpKeyFactory) RateHttpKeyFactory {
 	if len(factories) == 0 {
-		panic("factories cannot be empty")
+		return func(r *http.Request) string { return "" }
 	}
 
 	if len(factories) == 1 {
@@ -79,7 +79,7 @@ func ComposeRateKeyFactories(factories ...RateHttpKeyFactory) RateHttpKeyFactory
 	}
 }
 
-// RateLimitMiddleware returns httpf.Handler which used rate-limiting feature to decide if h Handler can be requested.
+// RateLimitMiddleware returns httpf.Handler which uses rate-limiting feature to decide if h Handler can be requested.
 // If rate limit exceeds maximum value, the error is returned and should be handled by ErrorHandler to actually
 // return 429 status code with appropiate body. This middleware writes all of
 // "X-Rate-Limit-Limit", "X-Rate-Limit-Remaining" and "X-Rate-Limit-Reset" headers with correct values.

--- a/httpf/rate.go
+++ b/httpf/rate.go
@@ -19,6 +19,11 @@ const (
 	RetryAfterHeader         = "Retry-After"
 )
 
+var (
+	ErrMissingRateStore      = errors.New("nil LimiterStore passed as parameter")
+	ErrMissingRateKeyFactory = errors.New("nil RateHttpKeyFactory passed as parameter")
+)
+
 // RateHttpKeyFactory is factory func to create a string key based on http.Request.
 type RateHttpKeyFactory func(r *http.Request) string
 
@@ -79,6 +84,12 @@ func ComposeRateKeyFactories(factories ...RateHttpKeyFactory) RateHttpKeyFactory
 // return 429 status code with appropiate body. This middleware writes all of
 // "X-Rate-Limit-Limit", "X-Rate-Limit-Remaining" and "X-Rate-Limit-Reset" headers with correct values.
 func RateLimitMiddleware(h Handler, store rate.LimiterStore, keyFactory RateHttpKeyFactory) Handler {
+	if store == nil {
+		panic(ErrMissingRateStore)
+	}
+	if keyFactory == nil {
+		panic(ErrMissingRateKeyFactory)
+	}
 	return HandlerFunc(func(w ResponseWriter, r *http.Request) error {
 		key := keyFactory(r)
 		ctx := r.Context()

--- a/httpf/rate_test.go
+++ b/httpf/rate_test.go
@@ -114,9 +114,11 @@ func TestComposeRateKeyFactories(t *testing.T) {
 
 	t.Run("failure-no-factories", func(t *testing.T) {
 		defer func() {
-			assert.NotNil(t, recover())
+			assert.Equal(t, nil, recover())
 		}()
-		_ = httpf.ComposeRateKeyFactories()
+		f := httpf.ComposeRateKeyFactories()
+		key := f(&http.Request{})
+		assert.Equal(t, "", key)
 	})
 }
 

--- a/rate/example_test.go
+++ b/rate/example_test.go
@@ -15,7 +15,10 @@ func Example() {
 		panic(err)
 	}
 
-	store := memory.NewLimiterStore(context.Background(), sw, time.Hour)
+	store, err := memory.NewLimiterStore(context.Background(), sw, time.Hour)
+	if err != nil {
+		panic(err)
+	}
 
 	l, err := store.Limit(context.Background(), "{id}")
 	if err != nil {


### PR DESCRIPTION
<!-- Describe the scope of changes for this pull request, the best way it to list all the changes with short description for each -->
### Changes

- `httpf.RecoverMiddleware` new middleware to recover and return error instead panic
- `httpf.ComposeRateKeyFactories` with no parameter value returns factory with empty string instead panic
- `httpf.RateLimitMiddleware` fails fast with panic if either store or keyFactory was not provided
- `memory.NewLimiterStore` change signature to return error if alghoritm is not provided
- `memory.LimiterStore` now does not run goroutine if cleanupInterval is <= 0

<!-- Share with additional decisions you had to make or other implementation details, warnings, important information -->
### Notes

-
